### PR TITLE
Add Jalali and Hijri Date Complication Service

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,6 +11,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven { url = uri("https://jitpack.io") }
     }
 }
 

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -113,6 +113,9 @@ dependencies {
     // HILT
     implementation ("androidx.hilt:hilt-navigation-compose:1.1.0")
     implementation ("com.google.dagger:hilt-android:2.48")
+
+    implementation("com.github.samanzamani:persiandate:1.7.1")
+
     kapt ("com.google.dagger:hilt-compiler:2.47")
 }
 // Allow references to generated code

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -115,6 +115,7 @@ dependencies {
     implementation ("com.google.dagger:hilt-android:2.48")
 
     implementation("com.github.samanzamani:persiandate:1.7.1")
+    implementation("com.jakewharton.threetenabp:threetenabp:1.3.1")
 
     kapt ("com.google.dagger:hilt-compiler:2.47")
 }

--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -129,6 +129,22 @@
         </service>
 
         <service
+            android:name=".complication.JalaliDateComplicationService"
+            android:exported="true"
+            android:icon="@drawable/ic_date"
+            android:label="@string/date_comp_jalali_name"
+            android:permission="com.google.android.wearable.permission.BIND_COMPLICATION_PROVIDER">
+            <intent-filter>
+                <action android:name="android.support.wearable.complications.ACTION_COMPLICATION_UPDATE_REQUEST" />
+            </intent-filter>
+            <meta-data android:name="android.support.wearable.complications.UPDATE_PERIOD_SECONDS" android:value="3600"/>
+
+            <meta-data
+                android:name="android.support.wearable.complications.SUPPORTED_TYPES"
+                android:value="SHORT_TEXT,LONG_TEXT" />
+        </service>
+
+        <service
             android:name=".complication.TimeComplicationService"
             android:exported="true"
             android:icon="@drawable/ic_clock"

--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -145,6 +145,22 @@
         </service>
 
         <service
+            android:name=".complication.HijriDateComplicationService"
+            android:exported="true"
+            android:icon="@drawable/ic_date"
+            android:label="@string/date_comp_hijri_name"
+            android:permission="com.google.android.wearable.permission.BIND_COMPLICATION_PROVIDER">
+            <intent-filter>
+                <action android:name="android.support.wearable.complications.ACTION_COMPLICATION_UPDATE_REQUEST" />
+            </intent-filter>
+            <meta-data android:name="android.support.wearable.complications.UPDATE_PERIOD_SECONDS" android:value="3600"/>
+
+            <meta-data
+                android:name="android.support.wearable.complications.SUPPORTED_TYPES"
+                android:value="SHORT_TEXT,LONG_TEXT" />
+        </service>
+
+        <service
             android:name=".complication.TimeComplicationService"
             android:exported="true"
             android:icon="@drawable/ic_clock"

--- a/wear/src/main/java/com/weartools/weekdayutccomp/complication/HijriDateComplicationService.kt
+++ b/wear/src/main/java/com/weartools/weekdayutccomp/complication/HijriDateComplicationService.kt
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2022 amoledwatchfaces™
+ * support@amoledwatchfaces.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.weartools.weekdayutccomp.complication
+
+import android.app.PendingIntent
+import android.content.Intent
+import android.util.Log
+import android.widget.Toast
+import androidx.datastore.core.DataStore
+import androidx.wear.watchface.complications.data.*
+import androidx.wear.watchface.complications.datasource.ComplicationRequest
+import androidx.wear.watchface.complications.datasource.SuspendingComplicationDataSourceService
+import com.weartools.weekdayutccomp.R
+import com.weartools.weekdayutccomp.preferences.UserPreferences
+import com.weartools.weekdayutccomp.preferences.UserPreferencesRepository
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.first
+import com.ibm.icu.util.Calendar
+import com.ibm.icu.util.IslamicCalendar
+import com.ibm.icu.util.ULocale
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class HijriDateComplicationService : SuspendingComplicationDataSourceService() {
+
+    @Inject
+    lateinit var dataStore: DataStore<UserPreferences>
+    private val preferences by lazy { UserPreferencesRepository(dataStore).getPreferences() }
+
+private fun openScreen(): PendingIntent? {
+
+    val calendarIntent = Intent()
+    calendarIntent.action = Intent.ACTION_MAIN
+    calendarIntent.addCategory(Intent.CATEGORY_APP_CALENDAR)
+
+    return PendingIntent.getActivity(
+        this, 0, calendarIntent,
+        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+    )
+}
+
+override fun getPreviewData(type: ComplicationType): ComplicationData? {
+    return when (type) {
+        ComplicationType.SHORT_TEXT -> ShortTextComplicationData.Builder(
+        text = PlainComplicationText.Builder(text = "17").build(),
+        contentDescription = PlainComplicationText
+            .Builder(text = getString(R.string.date_comp_name))
+            .build())
+        .setTitle(PlainComplicationText.Builder(text = "04").build())
+        .setTapAction(null)
+        .build()
+        ComplicationType.LONG_TEXT -> LongTextComplicationData.Builder(
+            text = PlainComplicationText.Builder(text = "01/01/2025").build(),
+            contentDescription = PlainComplicationText
+                .Builder(text = getString(R.string.date_comp_name))
+                .build()
+        )
+            .setTapAction(openScreen())
+            .build()
+        else -> {null}
+    }
+}
+
+override suspend fun onComplicationRequest(request: ComplicationRequest): ComplicationData? {
+    Log.d(TAG, "onComplicationRequest() id: ${request.complicationInstanceId}")
+
+    val prefs = preferences.first()
+    val longText = prefs.longText
+    val islamicCalendar = IslamicCalendar(ULocale.US)
+    val islamicMonth = islamicCalendar.get(Calendar.MONTH) + 1  // months are zero-based
+    val islamicDay = islamicCalendar.get(Calendar.DAY_OF_MONTH)
+
+    return when (request.complicationType) {
+        ComplicationType.SHORT_TEXT -> ShortTextComplicationData.Builder(
+
+            text = try {
+                PlainComplicationText.Builder(islamicDay.toString()).build()
+            } catch (e: IllegalArgumentException) {
+                // Inform the user that the format is invalid
+                Toast.makeText(this, "Text: Wrong format! Check SimpleDateFormat", Toast.LENGTH_LONG).show()
+                PlainComplicationText.Builder(text="?").build()
+            },
+            contentDescription = PlainComplicationText
+                .Builder(text = getString(R.string.date_comp_name))
+                .build()
+        )
+            .setTitle(
+                try {
+                    PlainComplicationText.Builder(islamicMonth.toString()).build()
+                } catch (e: IllegalArgumentException) {
+                    // Inform the user that the format is invalid
+                    Toast.makeText(this, "Title: Wrong format! Check SimpleDateFormat", Toast.LENGTH_LONG).show()
+                    PlainComplicationText.Builder(text="?").build()
+                }
+            )
+            .setTapAction(openScreen())
+            .build()
+
+        ComplicationType.LONG_TEXT -> LongTextComplicationData.Builder(
+            text = try {
+                TimeFormatComplicationText.Builder(format = longText).build()
+            } catch (e: IllegalArgumentException) {
+                // Inform the user that the format is invalid
+                Toast.makeText(this, "Wrong format! Check SimpleDateFormat patters", Toast.LENGTH_LONG).show()
+                PlainComplicationText.Builder(text="?").build()
+            },
+            contentDescription = PlainComplicationText
+                .Builder(text = getString(R.string.date_comp_name))
+                .build()
+        )
+            .setTapAction(openScreen())
+            .build()
+
+        else -> {
+            if (Log.isLoggable(TAG, Log.WARN)) {
+                Log.w(TAG, "Unexpected complication type ${request.complicationType}")
+            }
+            null
+        }
+
+    }
+}
+
+override fun onComplicationDeactivated(complicationInstanceId: Int) {
+    Log.d(TAG, "onComplicationDeactivated(): $complicationInstanceId")
+}
+
+companion object {
+    private const val TAG = "CompDataSourceService"
+}
+}
+

--- a/wear/src/main/java/com/weartools/weekdayutccomp/complication/HijriDateComplicationService.kt
+++ b/wear/src/main/java/com/weartools/weekdayutccomp/complication/HijriDateComplicationService.kt
@@ -18,6 +18,8 @@ package com.weartools.weekdayutccomp.complication
 
 import android.app.PendingIntent
 import android.content.Intent
+import android.icu.util.IslamicCalendar
+import android.icu.util.ULocale
 import android.util.Log
 import android.widget.Toast
 import androidx.datastore.core.DataStore
@@ -29,9 +31,7 @@ import com.weartools.weekdayutccomp.preferences.UserPreferences
 import com.weartools.weekdayutccomp.preferences.UserPreferencesRepository
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.first
-import com.ibm.icu.util.Calendar
-import com.ibm.icu.util.IslamicCalendar
-import com.ibm.icu.util.ULocale
+import java.util.*
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -60,7 +60,7 @@ override fun getPreviewData(type: ComplicationType): ComplicationData? {
         contentDescription = PlainComplicationText
             .Builder(text = getString(R.string.date_comp_name))
             .build())
-        .setTitle(PlainComplicationText.Builder(text = "04").build())
+        .setTitle(PlainComplicationText.Builder(text = "شعبان").build())
         .setTapAction(null)
         .build()
         ComplicationType.LONG_TEXT -> LongTextComplicationData.Builder(
@@ -81,8 +81,23 @@ override suspend fun onComplicationRequest(request: ComplicationRequest): Compli
     val prefs = preferences.first()
     val longText = prefs.longText
     val islamicCalendar = IslamicCalendar(ULocale.US)
-    val islamicMonth = islamicCalendar.get(Calendar.MONTH) + 1  // months are zero-based
+    val islamicMonth = islamicCalendar.get(Calendar.MONTH)  // months are zero-based
     val islamicDay = islamicCalendar.get(Calendar.DAY_OF_MONTH)
+    val islamicMonths = arrayOf(
+        "محرم",
+        "صفر",
+        "ربيع الأول",
+        "ربيع الثاني",
+        "جمادى الأولى",
+        "جمادى الثانية",
+        "رجب",
+        "شعبان",
+        "رمضان",
+        "شوال",
+        "ذو القعدة",
+        "ذو الحجة"
+    )
+    val month_name = islamicMonths[islamicMonth]
 
     return when (request.complicationType) {
         ComplicationType.SHORT_TEXT -> ShortTextComplicationData.Builder(
@@ -100,7 +115,7 @@ override suspend fun onComplicationRequest(request: ComplicationRequest): Compli
         )
             .setTitle(
                 try {
-                    PlainComplicationText.Builder(islamicMonth.toString()).build()
+                    PlainComplicationText.Builder(month_name).build()
                 } catch (e: IllegalArgumentException) {
                     // Inform the user that the format is invalid
                     Toast.makeText(this, "Title: Wrong format! Check SimpleDateFormat", Toast.LENGTH_LONG).show()

--- a/wear/src/main/java/com/weartools/weekdayutccomp/complication/JalaliDateComplicationService.kt
+++ b/wear/src/main/java/com/weartools/weekdayutccomp/complication/JalaliDateComplicationService.kt
@@ -59,7 +59,7 @@ override fun getPreviewData(type: ComplicationType): ComplicationData? {
         contentDescription = PlainComplicationText
             .Builder(text = getString(R.string.date_comp_name))
             .build())
-        .setTitle(PlainComplicationText.Builder(text = "04").build())
+        .setTitle(PlainComplicationText.Builder(text = "تیر").build())
         .setTapAction(null)
         .build()
         ComplicationType.LONG_TEXT -> LongTextComplicationData.Builder(
@@ -81,7 +81,7 @@ override suspend fun onComplicationRequest(request: ComplicationRequest): Compli
     val longText = prefs.longText
     val persianDate = PersianDate()
     val persianDayText = PersianDateFormat("d").format(persianDate)
-    val persianMonthText = PersianDateFormat("m").format(persianDate)
+    val persianMonthText = persianDate.monthName
 
     return when (request.complicationType) {
         ComplicationType.SHORT_TEXT -> ShortTextComplicationData.Builder(

--- a/wear/src/main/java/com/weartools/weekdayutccomp/complication/JalaliDateComplicationService.kt
+++ b/wear/src/main/java/com/weartools/weekdayutccomp/complication/JalaliDateComplicationService.kt
@@ -80,14 +80,14 @@ override suspend fun onComplicationRequest(request: ComplicationRequest): Compli
     val prefs = preferences.first()
     val longText = prefs.longText
     val persianDate = PersianDate()
-    val persianDateText = PersianDateFormat("d").format(persianDate)
+    val persianDayText = PersianDateFormat("d").format(persianDate)
     val persianMonthText = PersianDateFormat("m").format(persianDate)
 
     return when (request.complicationType) {
         ComplicationType.SHORT_TEXT -> ShortTextComplicationData.Builder(
 
             text = try {
-                PlainComplicationText.Builder(persianDateText.toString()).build()
+                PlainComplicationText.Builder(persianDayText.toString()).build()
             } catch (e: IllegalArgumentException) {
                 // Inform the user that the format is invalid
                 Toast.makeText(this, "Text: Wrong format! Check SimpleDateFormat", Toast.LENGTH_LONG).show()

--- a/wear/src/main/java/com/weartools/weekdayutccomp/complication/JalaliDateComplicationService.kt
+++ b/wear/src/main/java/com/weartools/weekdayutccomp/complication/JalaliDateComplicationService.kt
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2022 amoledwatchfaces™
+ * support@amoledwatchfaces.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.weartools.weekdayutccomp.complication
+
+import android.app.PendingIntent
+import android.content.Intent
+import android.util.Log
+import android.widget.Toast
+import androidx.datastore.core.DataStore
+import androidx.wear.watchface.complications.data.*
+import androidx.wear.watchface.complications.datasource.ComplicationRequest
+import androidx.wear.watchface.complications.datasource.SuspendingComplicationDataSourceService
+import com.weartools.weekdayutccomp.R
+import com.weartools.weekdayutccomp.preferences.UserPreferences
+import com.weartools.weekdayutccomp.preferences.UserPreferencesRepository
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.first
+import saman.zamani.persiandate.PersianDate
+import saman.zamani.persiandate.PersianDateFormat
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class JalaliDateComplicationService : SuspendingComplicationDataSourceService() {
+
+    @Inject
+    lateinit var dataStore: DataStore<UserPreferences>
+    private val preferences by lazy { UserPreferencesRepository(dataStore).getPreferences() }
+
+private fun openScreen(): PendingIntent? {
+
+    val calendarIntent = Intent()
+    calendarIntent.action = Intent.ACTION_MAIN
+    calendarIntent.addCategory(Intent.CATEGORY_APP_CALENDAR)
+
+    return PendingIntent.getActivity(
+        this, 0, calendarIntent,
+        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+    )
+}
+
+override fun getPreviewData(type: ComplicationType): ComplicationData? {
+    return when (type) {
+        ComplicationType.SHORT_TEXT -> ShortTextComplicationData.Builder(
+        text = PlainComplicationText.Builder(text = "17").build(),
+        contentDescription = PlainComplicationText
+            .Builder(text = getString(R.string.date_comp_name))
+            .build())
+        .setTitle(PlainComplicationText.Builder(text = "04").build())
+        .setTapAction(null)
+        .build()
+        ComplicationType.LONG_TEXT -> LongTextComplicationData.Builder(
+            text = PlainComplicationText.Builder(text = "01/01/2025").build(),
+            contentDescription = PlainComplicationText
+                .Builder(text = getString(R.string.date_comp_name))
+                .build()
+        )
+            .setTapAction(openScreen())
+            .build()
+        else -> {null}
+    }
+}
+
+override suspend fun onComplicationRequest(request: ComplicationRequest): ComplicationData? {
+    Log.d(TAG, "onComplicationRequest() id: ${request.complicationInstanceId}")
+
+    val prefs = preferences.first()
+    val longText = prefs.longText
+    val persianDate = PersianDate()
+    val persianDateText = PersianDateFormat("d").format(persianDate)
+    val persianMonthText = PersianDateFormat("m").format(persianDate)
+
+    return when (request.complicationType) {
+        ComplicationType.SHORT_TEXT -> ShortTextComplicationData.Builder(
+
+            text = try {
+                PlainComplicationText.Builder(persianDateText.toString()).build()
+            } catch (e: IllegalArgumentException) {
+                // Inform the user that the format is invalid
+                Toast.makeText(this, "Text: Wrong format! Check SimpleDateFormat", Toast.LENGTH_LONG).show()
+                PlainComplicationText.Builder(text="?").build()
+            },
+            contentDescription = PlainComplicationText
+                .Builder(text = getString(R.string.date_comp_name))
+                .build()
+        )
+            .setTitle(
+                try {
+                    PlainComplicationText.Builder(persianMonthText.toString()).build()
+                } catch (e: IllegalArgumentException) {
+                    // Inform the user that the format is invalid
+                    Toast.makeText(this, "Title: Wrong format! Check SimpleDateFormat", Toast.LENGTH_LONG).show()
+                    PlainComplicationText.Builder(text="?").build()
+                }
+            )
+            .setTapAction(openScreen())
+            .build()
+
+        ComplicationType.LONG_TEXT -> LongTextComplicationData.Builder(
+            text = try {
+                TimeFormatComplicationText.Builder(format = longText).build()
+            } catch (e: IllegalArgumentException) {
+                // Inform the user that the format is invalid
+                Toast.makeText(this, "Wrong format! Check SimpleDateFormat patters", Toast.LENGTH_LONG).show()
+                PlainComplicationText.Builder(text="?").build()
+            },
+            contentDescription = PlainComplicationText
+                .Builder(text = getString(R.string.date_comp_name))
+                .build()
+        )
+            .setTapAction(openScreen())
+            .build()
+
+        else -> {
+            if (Log.isLoggable(TAG, Log.WARN)) {
+                Log.w(TAG, "Unexpected complication type ${request.complicationType}")
+            }
+            null
+        }
+
+    }
+}
+
+override fun onComplicationDeactivated(complicationInstanceId: Int) {
+    Log.d(TAG, "onComplicationDeactivated(): $complicationInstanceId")
+}
+
+companion object {
+    private const val TAG = "CompDataSourceService"
+}
+}
+

--- a/wear/src/main/res/values/strings.xml
+++ b/wear/src/main/res/values/strings.xml
@@ -28,6 +28,7 @@
     <!-- Date Complication Preferences -->
     <string name="date_comp_name">Date</string>
     <string name="date_comp_jalali_name" translatable="false">Date Jalali</string>
+    <string name="date_comp_hijri_name" translatable="false">Date Hijri</string>
     <string name="date_custom_format">Custom format</string>
     <string name="date_setting_preference_category_title">Date Complication</string>
     <string name="date_long_text_format">Long Text Format</string>

--- a/wear/src/main/res/values/strings.xml
+++ b/wear/src/main/res/values/strings.xml
@@ -27,6 +27,7 @@
 
     <!-- Date Complication Preferences -->
     <string name="date_comp_name">Date</string>
+    <string name="date_comp_jalali_name" translatable="false">Date Jalali</string>
     <string name="date_custom_format">Custom format</string>
     <string name="date_setting_preference_category_title">Date Complication</string>
     <string name="date_long_text_format">Long Text Format</string>


### PR DESCRIPTION
New Jalali and Hijri Dates Complication service has been added. 
I have added jitpack.io to our settings.gradle.kts repositories and declared a dependency for 'com.github.samanzamani:persiandate:1.7.1' in our wear/build.gradle.kts. AndroidManifest.xml now includes service details for JalaliDateComplicationService. A corresponding new class JalaliDateComplicationService.kt has also been added under 'com.weartools.weekdayutccomp/complication'. The new service provides users the ability to view the date in the Jalali calendar format. A string resource for 'date_comp_jalali_name' has been added to facilitate this change.